### PR TITLE
Update CLI docs to reflect removal of redundant flags

### DIFF
--- a/cli.md
+++ b/cli.md
@@ -31,21 +31,15 @@ Subdomain-based routing requires that the subdomains are configured correctly in
 
 ```
 Flags:
-  -d, --docker-path string   Path to docker compose binary
   -h, --help                 Help for canasta
   -v, --verbose              Verbose output
 ```
 
-Most commands also accept these flags to identify a Canasta installation:
-
-- `-i, --id`: Canasta instance ID (the name you gave when creating the installation)
-- `-p, --path`: Path to the Canasta installation directory
-
-If you run commands from within the Canasta installation directory, the `-i` flag is not required.
+Most commands accept the `-i, --id` flag to identify a Canasta installation by the name you gave when creating it. If you run commands from within the Canasta installation directory, the `-i` flag is not required.
 
 ## Getting help
 
-Use `canasta help` or `canasta --help` to see the list of available commands. For help with a specific command, use:
+Running `canasta` with no arguments displays the full command listing and the location of the config file. For help with a specific command, use:
 
 ```bash
 canasta [command] --help

--- a/cli/backup.md
+++ b/cli/backup.md
@@ -43,7 +43,6 @@ These flags apply to all restic subcommands:
 | Flag | Short | Default | Description |
 |------|-------|---------|-------------|
 | `--id` | `-i` | | Canasta instance ID |
-| `--path` | `-p` | Current directory | Path to the Canasta installation |
 | `--verbose` | `-v` | `false` | Verbose output |
 
 ---

--- a/cli/canasta.md
+++ b/cli/canasta.md
@@ -23,7 +23,6 @@ canasta upgrade [flags]
 | Flag | Short | Default | Description |
 |------|-------|---------|-------------|
 | `--id` | `-i` | | Canasta instance ID |
-| `--path` | `-p` | Current directory | Path to the Canasta installation |
 
 **Example:**
 

--- a/cli/devmode.md
+++ b/cli/devmode.md
@@ -466,7 +466,6 @@ canasta start [flags]
 | `--dev` | `-D` | Start in development mode with Xdebug |
 | `--no-dev` | | Start without development mode (disable dev mode) |
 | `--id` | `-i` | Canasta instance ID |
-| `--path` | `-p` | Canasta installation directory |
 
 ### Restart command
 
@@ -479,6 +478,5 @@ canasta restart [flags]
 | `--dev` | `-D` | Restart in development mode with Xdebug |
 | `--no-dev` | | Restart without development mode (disable dev mode) |
 | `--id` | `-i` | Canasta instance ID |
-| `--path` | `-p` | Canasta installation directory |
 
 **Note:** You cannot specify both `--dev` and `--no-dev` at the same time.

--- a/cli/maintenance.md
+++ b/cli/maintenance.md
@@ -30,7 +30,6 @@ Manage Canasta extensions for a wiki installation.
 | Flag | Short | Default | Description |
 |------|-------|---------|-------------|
 | `--id` | `-i` | | Canasta instance ID |
-| `--path` | `-p` | Current directory | Path to the Canasta installation |
 | `--wiki` | `-w` | | ID of specific wiki in the farm (optional) |
 | `--verbose` | `-v` | `false` | Verbose output |
 
@@ -104,7 +103,6 @@ Manage Canasta skins for a wiki installation.
 | Flag | Short | Default | Description |
 |------|-------|---------|-------------|
 | `--id` | `-i` | | Canasta instance ID |
-| `--path` | `-p` | Current directory | Path to the Canasta installation |
 | `--wiki` | `-w` | | ID of specific wiki in the farm (optional) |
 | `--verbose` | `-v` | `false` | Verbose output |
 
@@ -167,7 +165,6 @@ Run maintenance scripts for a Canasta installation.
 | Flag | Short | Default | Description |
 |------|-------|---------|-------------|
 | `--id` | `-i` | | Canasta instance ID |
-| `--path` | `-p` | Current directory | Path to the Canasta installation |
 
 ### canasta maintenance update
 
@@ -216,11 +213,8 @@ canasta start [flags]
 | Flag | Short | Default | Description |
 |------|-------|---------|-------------|
 | `--id` | `-i` | | Canasta instance ID |
-| `--path` | `-p` | Current directory | Path to the Canasta installation |
-| `--orchestrator` | `-o` | `compose` | Orchestrator to use |
 | `--dev` | `-D` | | Start in development mode with Xdebug (see [Development mode](devmode.md)) |
 | `--no-dev` | | | Start without development mode (disable dev mode) |
-| `--dev-tag` | | `latest` | Canasta image tag to use for dev mode |
 
 **Examples:**
 
@@ -249,8 +243,6 @@ canasta stop [flags]
 | Flag | Short | Default | Description |
 |------|-------|---------|-------------|
 | `--id` | `-i` | | Canasta instance ID |
-| `--path` | `-p` | Current directory | Path to the Canasta installation |
-| `--orchestrator` | `-o` | `compose` | Orchestrator to use |
 
 **Example:**
 
@@ -274,12 +266,9 @@ canasta restart [flags]
 | Flag | Short | Default | Description |
 |------|-------|---------|-------------|
 | `--id` | `-i` | | Canasta instance ID |
-| `--path` | `-p` | Current directory | Path to the Canasta installation |
-| `--orchestrator` | `-o` | `compose` | Orchestrator to use |
 | `--verbose` | `-v` | `false` | Verbose output |
 | `--dev` | `-D` | | Restart in development mode with Xdebug (see [Development mode](devmode.md)) |
 | `--no-dev` | | | Restart without development mode (disable dev mode) |
-| `--dev-tag` | | `latest` | Canasta image tag to use for dev mode |
 
 **Examples:**
 

--- a/cli/wiki-management.md
+++ b/cli/wiki-management.md
@@ -149,8 +149,6 @@ canasta add [flags]
 
 | Flag | Short | Default | Description |
 |------|-------|---------|-------------|
-| `--path` | `-p` | Current directory | Path to the Canasta installation |
-| `--orchestrator` | `-o` | `compose` | Orchestrator to use |
 | `--site-name` | `-t` | Wiki ID | Display name of the wiki |
 | `--database` | `-d` | | Path to existing database dump |
 | `--password` | `-s` | Auto-generated | Admin password for the new wiki |
@@ -196,7 +194,6 @@ canasta remove [flags]
 |------|-------|---------|-------------|
 | `--wiki` | `-w` | | ID of the wiki to remove (required) |
 | `--id` | `-i` | | Canasta instance ID |
-| `--path` | `-p` | Current directory | Path to the Canasta installation |
 
 **Example:**
 
@@ -222,7 +219,6 @@ canasta delete [flags]
 | Flag | Short | Default | Description |
 |------|-------|---------|-------------|
 | `--id` | `-i` | | Canasta instance ID |
-| `--path` | `-p` | Current directory | Path to the Canasta installation |
 
 **Example:**
 


### PR DESCRIPTION
Remove --path and --orchestrator flags from documentation for all commands except create, matching PR #146. Remove --docker-path from global flags. Update help section to describe the new default behavior of showing the command listing and config file location.

Commands updated: add, remove, delete, start, stop, restart, upgrade, extension, skin, maintenance, restic. The create and import command docs are unchanged since create still has these flags and import has not yet been replaced.

Related PRs:
* CanastaWiki/Canasta-CLI#146
* CanastaWiki/Canasta-CLI#147